### PR TITLE
Fix: Add Python 3.12 support

### DIFF
--- a/altium_schematic_parser/parse.py
+++ b/altium_schematic_parser/parse.py
@@ -31,7 +31,7 @@ def parse(input, format, **kwargs):
             data = pair.split(b"=")
             # only add to dict if we have both a key and a value
             if len(data) >= 2:
-                datum[data[0].decode()] = data[1].decode('utf-8', 'ignore')
+                datum[data[0].decode('utf-8', 'ignore')] = data[1].decode('utf-8', 'ignore')
 
         datums.append(datum)
 
@@ -93,7 +93,7 @@ def determine_net_list(schematic):
     _, power_ports = find_record(schematic, key="RECORD", value="17")
     devices = wires + pins + labels + power_ports
 
-    p = re.compile('^(?P<prefix>X)(?P<index>\\d+)$')
+    p = re.compile(r'^(?P<prefix>X)(?P<index>\d+)$')
     for device in devices:
         # if a Pin, do some fancy geometry math
         if device["RECORD"] == "2":

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 import os
 from setuptools import setup, find_packages
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
     
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname), encoding="utf-8").read()
 
 setup(
     name='Altium-Schematic-Parser',


### PR DESCRIPTION
This PR fixes issues preventing the parser from running on Python 3.12+.

Changes:
- Fixed `SyntaxWarning: invalid escape sequence` by using raw strings for regex patterns.
- Fixed `UnicodeDecodeError` when parsing OLE stream data by ignoring invalid UTF-8 bytes in keys/values.
- Fixed `UnicodeDecodeError` in `setup.py` by enforcing UTF-8 encoding when reading `README.md` and `requirements.txt`.

Fixes #13